### PR TITLE
Fix typos on home page

### DIFF
--- a/AppleWebApp/Pages/Index.cshtml
+++ b/AppleWebApp/Pages/Index.cshtml
@@ -6,9 +6,9 @@
 
 <div class="text-center">
     <h1 class="display-4">Welcome by Zeb for Apple</h1>
-    Sampel Web App to play with Github
+    Sample Web App to play with GitHub
     <br/>
     
-    Changes from the Github
+    Changes from the GitHub
     <p>Learn about <a href="https://docs.microsoft.com/aspnet/core">building Web apps with ASP.NET Core</a>.</p>
 </div>

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # AppleWebApp
+
+Simple web application for demonstration purposes.


### PR DESCRIPTION
## Summary
- correct typos on the home page
- clarify README description

## Testing
- `dotnet build AppleWebApp.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866d7e2a5148332bb672823f7142ef8